### PR TITLE
In Game Menu

### DIFF
--- a/Assets/Prefabs/Characters/TestCharacter.prefab
+++ b/Assets/Prefabs/Characters/TestCharacter.prefab
@@ -160,12 +160,12 @@ MonoBehaviour:
   gravityForce: {x: 0, y: -9.8, z: 0}
   jumpForce: 5
   maxWalkAngle: 45
-  groundCheckDistance: 0.1
+  groundCheckDistance: 0.01
   fallAnglePower: 1.2
-  moveAnglePower: 1.8
+  moveAnglePower: 2
   pushPower: 20
   movemaxBounces: 3
-  fallMaxBounces: 3
+  fallMaxBounces: 2
   pushDecay: 0
 --- !u!114 &2032777291050987007
 MonoBehaviour:
@@ -192,7 +192,7 @@ MonoBehaviour:
     Value:
       x: -90
       y: 0
-      z: 90
+      z: -90
     RotationOrder: 4
   m_Capsule:
     Height: 2
@@ -396,10 +396,10 @@ MonoBehaviour:
   PredictingPlayerNetworkId: PropHunt.Mixed.Components.PlayerId.playerId
   Components:
   - name: PropHunt.Mixed.Components.KCCGravity
-    interpolatedClient: 0
+    interpolatedClient: 1
     predictedClient: 1
     server: 1
-    sendDataTo: 2
+    sendDataTo: 0
     fields:
     - name: gravityAcceleration
       quantization: 100
@@ -476,7 +476,7 @@ MonoBehaviour:
     interpolatedClient: 0
     predictedClient: 1
     server: 1
-    sendDataTo: 2
+    sendDataTo: 0
     fields:
     - name: playerVelocity
       quantization: 100
@@ -501,7 +501,7 @@ MonoBehaviour:
     interpolatedClient: 0
     predictedClient: 1
     server: 1
-    sendDataTo: 2
+    sendDataTo: 0
     fields:
     - name: viewRotationRate
       quantization: 100

--- a/Assets/Prefabs/Characters/TestCharacter.prefab
+++ b/Assets/Prefabs/Characters/TestCharacter.prefab
@@ -160,12 +160,12 @@ MonoBehaviour:
   gravityForce: {x: 0, y: -9.8, z: 0}
   jumpForce: 5
   maxWalkAngle: 45
-  groundCheckDistance: 0.01
+  groundCheckDistance: 0.1
   fallAnglePower: 1.2
-  moveAnglePower: 2
+  moveAnglePower: 1.8
   pushPower: 20
   movemaxBounces: 3
-  fallMaxBounces: 2
+  fallMaxBounces: 3
   pushDecay: 0
 --- !u!114 &2032777291050987007
 MonoBehaviour:
@@ -396,10 +396,10 @@ MonoBehaviour:
   PredictingPlayerNetworkId: PropHunt.Mixed.Components.PlayerId.playerId
   Components:
   - name: PropHunt.Mixed.Components.KCCGravity
-    interpolatedClient: 1
+    interpolatedClient: 0
     predictedClient: 1
     server: 1
-    sendDataTo: 0
+    sendDataTo: 2
     fields:
     - name: gravityAcceleration
       quantization: 100
@@ -476,7 +476,7 @@ MonoBehaviour:
     interpolatedClient: 0
     predictedClient: 1
     server: 1
-    sendDataTo: 0
+    sendDataTo: 2
     fields:
     - name: playerVelocity
       quantization: 100
@@ -501,7 +501,7 @@ MonoBehaviour:
     interpolatedClient: 0
     predictedClient: 1
     server: 1
-    sendDataTo: 0
+    sendDataTo: 2
     fields:
     - name: viewRotationRate
       quantization: 100

--- a/Assets/Prefabs/UI.meta
+++ b/Assets/Prefabs/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 349e320bd410d8745a98d1895891ac99
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/InGameHUD.prefab
+++ b/Assets/Prefabs/UI/InGameHUD.prefab
@@ -1,0 +1,100 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6151485492143575393
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6151485492143575405}
+  - component: {fileID: 6151485492143575404}
+  - component: {fileID: 6151485492143575407}
+  - component: {fileID: 6151485492143575406}
+  m_Layer: 5
+  m_Name: InGameMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6151485492143575405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &6151485492143575404
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6151485492143575407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &6151485492143575406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295

--- a/Assets/Prefabs/UI/InGameHUD.prefab.meta
+++ b/Assets/Prefabs/UI/InGameHUD.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a2a778031f715b1438e2364c9b4fc7d1
+guid: f0c2c2ae7cc1ab548b9d45ee4f8864df
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Prefabs/UI/InGameMenu.prefab
+++ b/Assets/Prefabs/UI/InGameMenu.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &154027094116737051
+--- !u!1 &736789863084481633
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,149 +8,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5973676270025520681}
-  - component: {fileID: 8467629958309702598}
-  - component: {fileID: 1014442338127169147}
-  - component: {fileID: 7261324817427325046}
+  - component: {fileID: 7851579840359517740}
+  - component: {fileID: 2923948708056732668}
+  - component: {fileID: 7661981311809011232}
+  - component: {fileID: 5275007165047364920}
   m_Layer: 5
-  m_Name: ReturnButton
+  m_Name: Disconnect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &5973676270025520681
+--- !u!224 &7851579840359517740
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 154027094116737051}
+  m_GameObject: {fileID: 736789863084481633}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1426731071880228358}
-  m_Father: {fileID: 6151485492143575405}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 44}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &8467629958309702598
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 154027094116737051}
-  m_CullTransparentMesh: 0
---- !u!114 &1014442338127169147
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 154027094116737051}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &7261324817427325046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 154027094116737051}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1014442338127169147}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!1 &2858957737394206576
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6422846211618158999}
-  - component: {fileID: 4999888860309247046}
-  - component: {fileID: 5044422987210866860}
-  - component: {fileID: 2727100778153599788}
-  m_Layer: 5
-  m_Name: DisconnecButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6422846211618158999
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858957737394206576}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1108111549119553366}
-  m_Father: {fileID: 6151485492143575405}
+  - {fileID: 3377491519382874714}
+  m_Father: {fileID: 9012516056103054909}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -158,21 +39,21 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &4999888860309247046
+--- !u!222 &2923948708056732668
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858957737394206576}
+  m_GameObject: {fileID: 736789863084481633}
   m_CullTransparentMesh: 0
---- !u!114 &5044422987210866860
+--- !u!114 &7661981311809011232
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858957737394206576}
+  m_GameObject: {fileID: 736789863084481633}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -195,13 +76,13 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &2727100778153599788
+--- !u!114 &5275007165047364920
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2858957737394206576}
+  m_GameObject: {fileID: 736789863084481633}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -234,11 +115,11 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 5044422987210866860}
+  m_TargetGraphic: {fileID: 7661981311809011232}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!1 &3165659188122990938
+--- !u!1 &5166412537738579464
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -246,9 +127,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1426731071880228358}
-  - component: {fileID: 1669944682963169537}
-  - component: {fileID: 1371802962299018559}
+  - component: {fileID: 5443701651117432784}
+  - component: {fileID: 1993487345723850590}
+  - component: {fileID: 5064985265430320901}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -256,40 +137,40 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1426731071880228358
+--- !u!224 &5443701651117432784
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3165659188122990938}
+  m_GameObject: {fileID: 5166412537738579464}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 5973676270025520681}
+  m_Father: {fileID: 5481731862031375104}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_AnchoredPosition: {x: 0.000091552734, y: -0.000015258789}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &1669944682963169537
+--- !u!222 &1993487345723850590
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3165659188122990938}
+  m_GameObject: {fileID: 5166412537738579464}
   m_CullTransparentMesh: 0
---- !u!114 &1371802962299018559
+--- !u!114 &5064985265430320901
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3165659188122990938}
+  m_GameObject: {fileID: 5166412537738579464}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -315,8 +196,8 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Return To Game
---- !u!1 &3556368111324427987
+  m_Text: Back to Game
+--- !u!1 &5209135667157588445
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -324,9 +205,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1108111549119553366}
-  - component: {fileID: 6914552491120966552}
-  - component: {fileID: 2237111064677581297}
+  - component: {fileID: 3377491519382874714}
+  - component: {fileID: 8676720452685310374}
+  - component: {fileID: 1815540904268584595}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -334,40 +215,40 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1108111549119553366
+--- !u!224 &3377491519382874714
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3556368111324427987}
+  m_GameObject: {fileID: 5209135667157588445}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 6422846211618158999}
+  m_Father: {fileID: 7851579840359517740}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_AnchoredPosition: {x: 0.000091552734, y: -0.000015258789}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6914552491120966552
+--- !u!222 &8676720452685310374
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3556368111324427987}
+  m_GameObject: {fileID: 5209135667157588445}
   m_CullTransparentMesh: 0
---- !u!114 &2237111064677581297
+--- !u!114 &1815540904268584595
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3556368111324427987}
+  m_GameObject: {fileID: 5209135667157588445}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -394,7 +275,7 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Disconnect
---- !u!1 &6151485492143575393
+--- !u!1 &5894663433040089826
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -402,10 +283,142 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6151485492143575405}
-  - component: {fileID: 6151485492143575404}
-  - component: {fileID: 6151485492143575407}
-  - component: {fileID: 6151485492143575406}
+  - component: {fileID: 5481731862031375104}
+  - component: {fileID: 7445824191017741932}
+  - component: {fileID: 4172864764222142530}
+  - component: {fileID: 3435663582209444420}
+  m_Layer: 5
+  m_Name: Back
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5481731862031375104
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894663433040089826}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5443701651117432784}
+  m_Father: {fileID: 9012516056103054909}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 43}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7445824191017741932
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894663433040089826}
+  m_CullTransparentMesh: 0
+--- !u!114 &4172864764222142530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894663433040089826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3435663582209444420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5894663433040089826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4172864764222142530}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 199260564935243663}
+        m_MethodName: SetScreen
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 6151485492143575393, guid: f0c2c2ae7cc1ab548b9d45ee4f8864df,
+            type: 3}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &9012516056103054897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9012516056103054909}
+  - component: {fileID: 9012516056103054908}
+  - component: {fileID: 9012516056103054911}
+  - component: {fileID: 9012516056103054910}
+  - component: {fileID: 199260564935243663}
   m_Layer: 5
   m_Name: InGameMenu
   m_TagString: Untagged
@@ -413,19 +426,19 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &6151485492143575405
+--- !u!224 &9012516056103054909
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6151485492143575393}
+  m_GameObject: {fileID: 9012516056103054897}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 6422846211618158999}
-  - {fileID: 5973676270025520681}
+  - {fileID: 7851579840359517740}
+  - {fileID: 5481731862031375104}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -434,13 +447,13 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!223 &6151485492143575404
+--- !u!223 &9012516056103054908
 Canvas:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6151485492143575393}
+  m_GameObject: {fileID: 9012516056103054897}
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
@@ -455,13 +468,13 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &6151485492143575407
+--- !u!114 &9012516056103054911
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6151485492143575393}
+  m_GameObject: {fileID: 9012516056103054897}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
@@ -477,13 +490,13 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
---- !u!114 &6151485492143575406
+--- !u!114 &9012516056103054910
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6151485492143575393}
+  m_GameObject: {fileID: 9012516056103054897}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
@@ -494,3 +507,15 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &199260564935243663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9012516056103054897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ee52dadfaa455148a69c5d23ea72b37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UI/InGameMenu.prefab
+++ b/Assets/Prefabs/UI/InGameMenu.prefab
@@ -1,0 +1,100 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6151485492143575393
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6151485492143575405}
+  - component: {fileID: 6151485492143575404}
+  - component: {fileID: 6151485492143575407}
+  - component: {fileID: 6151485492143575406}
+  m_Layer: 5
+  m_Name: InGameMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6151485492143575405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &6151485492143575404
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6151485492143575407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &6151485492143575406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6151485492143575393}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295

--- a/Assets/Prefabs/UI/InGameMenu.prefab
+++ b/Assets/Prefabs/UI/InGameMenu.prefab
@@ -1,5 +1,399 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &154027094116737051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5973676270025520681}
+  - component: {fileID: 8467629958309702598}
+  - component: {fileID: 1014442338127169147}
+  - component: {fileID: 7261324817427325046}
+  m_Layer: 5
+  m_Name: ReturnButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5973676270025520681
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 154027094116737051}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1426731071880228358}
+  m_Father: {fileID: 6151485492143575405}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 44}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8467629958309702598
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 154027094116737051}
+  m_CullTransparentMesh: 0
+--- !u!114 &1014442338127169147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 154027094116737051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7261324817427325046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 154027094116737051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1014442338127169147}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &2858957737394206576
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6422846211618158999}
+  - component: {fileID: 4999888860309247046}
+  - component: {fileID: 5044422987210866860}
+  - component: {fileID: 2727100778153599788}
+  m_Layer: 5
+  m_Name: DisconnecButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6422846211618158999
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2858957737394206576}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1108111549119553366}
+  m_Father: {fileID: 6151485492143575405}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4999888860309247046
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2858957737394206576}
+  m_CullTransparentMesh: 0
+--- !u!114 &5044422987210866860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2858957737394206576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2727100778153599788
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2858957737394206576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5044422987210866860}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &3165659188122990938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1426731071880228358}
+  - component: {fileID: 1669944682963169537}
+  - component: {fileID: 1371802962299018559}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1426731071880228358
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165659188122990938}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5973676270025520681}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1669944682963169537
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165659188122990938}
+  m_CullTransparentMesh: 0
+--- !u!114 &1371802962299018559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165659188122990938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Return To Game
+--- !u!1 &3556368111324427987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1108111549119553366}
+  - component: {fileID: 6914552491120966552}
+  - component: {fileID: 2237111064677581297}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1108111549119553366
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3556368111324427987}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6422846211618158999}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6914552491120966552
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3556368111324427987}
+  m_CullTransparentMesh: 0
+--- !u!114 &2237111064677581297
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3556368111324427987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Disconnect
 --- !u!1 &6151485492143575393
 GameObject:
   m_ObjectHideFlags: 0
@@ -29,7 +423,9 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 6422846211618158999}
+  - {fileID: 5973676270025520681}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/UI/InGameMenu.prefab.meta
+++ b/Assets/Prefabs/UI/InGameMenu.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f0c2c2ae7cc1ab548b9d45ee4f8864df
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2802,84 +2802,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1223281601}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1332593325
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1332593326}
-  - component: {fileID: 1332593328}
-  - component: {fileID: 1332593327}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1332593326
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1332593325}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1746821455}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1332593327
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1332593325}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Button
---- !u!222 &1332593328
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1332593325}
-  m_CullTransparentMesh: 0
 --- !u!1001 &1341817203
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3261,12 +3183,6 @@ Transform:
   m_Father: {fileID: 813477144}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
---- !u!224 &1579575810 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6151485492143575405, guid: f0c2c2ae7cc1ab548b9d45ee4f8864df,
-    type: 3}
-  m_PrefabInstance: {fileID: 6151485493596454118}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1587951371
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3720,125 +3636,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1341817203}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1746821454
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1746821455}
-  - component: {fileID: 1746821458}
-  - component: {fileID: 1746821457}
-  - component: {fileID: 1746821456}
-  m_Layer: 5
-  m_Name: Button
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1746821455
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746821454}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1332593326}
-  m_Father: {fileID: 1579575810}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1746821456
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746821454}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 1746821457}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1746821457
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746821454}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1746821458
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746821454}
-  m_CullTransparentMesh: 0
 --- !u!1 &1759727441
 GameObject:
   m_ObjectHideFlags: 0
@@ -4303,6 +4100,53 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1dbed581fc5070947b76765ee5f861a7, type: 3}
+--- !u!1 &1899402781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1899402782}
+  - component: {fileID: 1899402783}
+  m_Layer: 0
+  m_Name: UIManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1899402782
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1899402781}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 557.5, y: 218.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1899402783
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1899402781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb7b9320169ee8d469ea7ba143194c4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  screenPrefabs:
+  - {fileID: 6151485492143575404, guid: f0c2c2ae7cc1ab548b9d45ee4f8864df, type: 3}
+  - {fileID: 9012516056103054908, guid: a2a778031f715b1438e2364c9b4fc7d1, type: 3}
+  initialScreen: 0
 --- !u!4 &1919316920 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 480558110488250732, guid: 1dbed581fc5070947b76765ee5f861a7,
@@ -4603,6 +4447,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1dbed581fc5070947b76765ee5f861a7, type: 3}
+<<<<<<< HEAD
 --- !u!1001 &6545281331079485700
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4672,3 +4517,5 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a4cef559ba10493488eee27e4be8a34a, type: 3}
+=======
+>>>>>>> Added basic in game UI/HUD manager

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -379,7 +379,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1001 &187340716
 PrefabInstance:
@@ -876,6 +876,72 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1dbed581fc5070947b76765ee5f861a7, type: 3}
+--- !u!1 &395957923
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 395957926}
+  - component: {fileID: 395957925}
+  - component: {fileID: 395957924}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &395957924
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395957923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &395957925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395957923}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &395957926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395957923}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &406710526
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1437,7 +1503,7 @@ Transform:
   - {fileID: 975970875}
   - {fileID: 279584122}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &719056214
 MonoBehaviour:
@@ -3638,7 +3704,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!20 &1788227365
 Camera:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2802,6 +2802,84 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1223281601}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1332593325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1332593326}
+  - component: {fileID: 1332593328}
+  - component: {fileID: 1332593327}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1332593326
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332593325}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1746821455}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1332593327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332593325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Button
+--- !u!222 &1332593328
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332593325}
+  m_CullTransparentMesh: 0
 --- !u!1001 &1341817203
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3183,6 +3261,12 @@ Transform:
   m_Father: {fileID: 813477144}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!224 &1579575810 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6151485492143575405, guid: f0c2c2ae7cc1ab548b9d45ee4f8864df,
+    type: 3}
+  m_PrefabInstance: {fileID: 6151485493596454118}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1587951371
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3636,6 +3720,125 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1341817203}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1746821454
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1746821455}
+  - component: {fileID: 1746821458}
+  - component: {fileID: 1746821457}
+  - component: {fileID: 1746821456}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1746821455
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746821454}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1332593326}
+  m_Father: {fileID: 1579575810}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1746821456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746821454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1746821457}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1746821457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746821454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1746821458
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746821454}
+  m_CullTransparentMesh: 0
 --- !u!1 &1759727441
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -4125,7 +4125,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1899402781}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 557.5, y: 218.75, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -4447,7 +4447,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1dbed581fc5070947b76765ee5f861a7, type: 3}
-<<<<<<< HEAD
 --- !u!1001 &6545281331079485700
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4517,5 +4516,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a4cef559ba10493488eee27e4be8a34a, type: 3}
-=======
->>>>>>> Added basic in game UI/HUD manager

--- a/Assets/Scripts/Client/Systems/MenuManagerSystem.cs
+++ b/Assets/Scripts/Client/Systems/MenuManagerSystem.cs
@@ -1,0 +1,61 @@
+
+using Unity.Burst;
+using Unity.Entities;
+using Unity.NetCode;
+using UnityEngine;
+
+namespace PropHunt.Client.Systems
+{
+    /// <summary>
+    /// Enum to control locking the current player input. This could be for things such
+    /// as a pause menu or other options.
+    /// </summary>
+    public enum LockedInputState {ALLOW, DENY};
+
+    /// <summary>
+    /// System to manage the available menu and
+    /// switch between different menus.
+    /// </summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(ClientSimulationSystemGroup))]
+    public class MenuManagerSystem : ComponentSystem
+    {
+        /// <summary>
+        /// Current movement input state of the player
+        /// </summary>
+        private static LockedInputState movementState = LockedInputState.ALLOW;
+
+        /// <summary>
+        /// Public get method for the current movement state of the player
+        /// </summary>
+        public static LockedInputState MovementState => MenuManagerSystem.movementState;
+
+        protected override void OnUpdate()
+        {
+            // Parse user input to check if the toggle menu button has been pressed
+            if (Input.GetButtonDown("Cancel"))
+            {
+                if (movementState == LockedInputState.ALLOW)
+                {
+                    MenuManagerSystem.movementState = LockedInputState.DENY;
+                }
+                else if (movementState == LockedInputState.DENY)
+                {
+                    MenuManagerSystem.movementState = LockedInputState.ALLOW;
+                }
+            }
+
+            // Set cursor visibility based on current user input
+            if (movementState == LockedInputState.ALLOW)
+            {
+                Cursor.lockState = CursorLockMode.Confined;
+                Cursor.visible = false;
+            }
+            else if (movementState == LockedInputState.DENY)
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Client/Systems/MenuManagerSystem.cs
+++ b/Assets/Scripts/Client/Systems/MenuManagerSystem.cs
@@ -1,4 +1,4 @@
-
+using PropHunt.UI;
 using Unity.Burst;
 using Unity.Entities;
 using Unity.NetCode;
@@ -30,6 +30,39 @@ namespace PropHunt.Client.Systems
         /// </summary>
         public static LockedInputState MovementState => MenuManagerSystem.movementState;
 
+        /// <summary>
+        /// Screen with in game menu options
+        /// </summary>
+        public static readonly string MenuScreen = "InGameMenu";
+
+        /// <summary>
+        /// Screen with in game heads up display name
+        /// </summary>
+        public static readonly string HUDScreen = "InGameHUD";
+
+        protected override void OnCreate()
+        {
+            // Add listener to screen change events
+            UIManager.ScreenChangeOccur += this.HandleScreenChangeEvent;
+        }
+
+        protected override void OnDestroy()
+        {
+            UIManager.ScreenChangeOccur -= this.HandleScreenChangeEvent;
+        }
+
+        /// <summary>
+        /// Handle events when the screen changes to ensure movement state
+        /// is unlocked while the in game heads up display is shown.
+        /// </summary>
+        private void HandleScreenChangeEvent(object sender, ScreenChangeEventArgs eventArgs)
+        {
+            if (eventArgs.newScreen == MenuManagerSystem.HUDScreen)
+            {
+                MenuManagerSystem.movementState = LockedInputState.ALLOW;
+            }
+        }
+
         protected override void OnUpdate()
         {
             // Parse user input to check if the toggle menu button has been pressed
@@ -38,10 +71,12 @@ namespace PropHunt.Client.Systems
                 if (movementState == LockedInputState.ALLOW)
                 {
                     MenuManagerSystem.movementState = LockedInputState.DENY;
+                    UIManager.RequestNewScreen(this, MenuManagerSystem.MenuScreen);
                 }
                 else if (movementState == LockedInputState.DENY)
                 {
                     MenuManagerSystem.movementState = LockedInputState.ALLOW;
+                    UIManager.RequestNewScreen(this, MenuManagerSystem.HUDScreen);
                 }
             }
 

--- a/Assets/Scripts/Client/Systems/MenuManagerSystem.cs.meta
+++ b/Assets/Scripts/Client/Systems/MenuManagerSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8735d9108e90ee94f862b43873cd6e7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Client/Systems/SamplePlayerInput.cs
+++ b/Assets/Scripts/Client/Systems/SamplePlayerInput.cs
@@ -8,7 +8,6 @@ using Unity.Burst;
 
 namespace PropHunt.Client.Systems
 {
-
     /// <summary>
     /// Systemt to sample player input at each tick.
     /// </summary>

--- a/Assets/Scripts/Client/Systems/SamplePlayerInput.cs
+++ b/Assets/Scripts/Client/Systems/SamplePlayerInput.cs
@@ -37,12 +37,12 @@ namespace PropHunt.Client.Systems
         {
             if (Input.GetButtonDown("Cancel"))
             {
-                if (Cursor.lockState == CursorLockMode.None)
+                if (movementState == LockedInputState.ALLOW)
                 {
                     Cursor.lockState = CursorLockMode.Locked;
                     this.movementState = LockedInputState.DENY;
                 }
-                else if (Cursor.lockState == CursorLockMode.Locked)
+                else if (movementState == LockedInputState.DENY)
                 {
                     Cursor.lockState = CursorLockMode.None;
                     this.movementState = LockedInputState.ALLOW;
@@ -75,6 +75,16 @@ namespace PropHunt.Client.Systems
                 input.interact = (byte) (Input.GetButtonDown("Interact") ? 1 : 0);
                 input.jump = (byte) (Input.GetButton("Jump") ? 1 : 0);
                 input.sprint = (byte) (Input.GetButton("Sprint") ? 1 : 0);
+            }
+            else
+            {
+                input.horizMove = 0;
+                input.vertMove  = 0;
+                input.pitchChange = 0;
+                input.yawChange = 0;
+                input.interact = 0;
+                input.jump = 0;
+                input.sprint = 0;
             }
             
             var inputBuffer = EntityManager.GetBuffer<PlayerInput>(localInput);

--- a/Assets/Scripts/Client/Systems/SamplePlayerInput.cs
+++ b/Assets/Scripts/Client/Systems/SamplePlayerInput.cs
@@ -14,18 +14,9 @@ namespace PropHunt.Client.Systems
     /// </summary>
     [BurstCompile]
     [UpdateInGroup(typeof(ClientSimulationSystemGroup))]
+    [UpdateAfter(typeof(MenuManagerSystem))]
     public class SamplePlayerInput : ComponentSystem
     {
-        /// <summary>
-        /// Enum to control locking the current player input. This could be for things such
-        /// as a pause menu or other options.
-        /// </summary>
-        private enum LockedInputState {ALLOW, DENY};
-
-        /// <summary>
-        /// Current movement input state of the player
-        /// </summary>
-        private LockedInputState movementState = LockedInputState.ALLOW;
 
         protected override void OnCreate()
         {
@@ -35,20 +26,6 @@ namespace PropHunt.Client.Systems
 
         protected override void OnUpdate()
         {
-            if (Input.GetButtonDown("Cancel"))
-            {
-                if (movementState == LockedInputState.ALLOW)
-                {
-                    Cursor.lockState = CursorLockMode.Locked;
-                    this.movementState = LockedInputState.DENY;
-                }
-                else if (movementState == LockedInputState.DENY)
-                {
-                    Cursor.lockState = CursorLockMode.None;
-                    this.movementState = LockedInputState.ALLOW;
-                }
-            }
-
             var localInput = GetSingleton<CommandTargetComponent>().targetEntity;
             if (localInput == Entity.Null)
             {
@@ -66,7 +43,7 @@ namespace PropHunt.Client.Systems
             var input = default(PlayerInput);
             input.tick = World.GetExistingSystem<ClientSimulationSystemGroup>().ServerTick;
 
-            if (this.movementState == LockedInputState.ALLOW) 
+            if (MenuManagerSystem.MovementState == LockedInputState.ALLOW) 
             {
                 input.horizMove = Input.GetAxis("Horizontal");
                 input.vertMove  = Input.GetAxis("Vertical");

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68a7471cffed13d4783f57bdcef867ff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+
+namespace PropHunt.UI
+{
+    public class MenuController : MonoBehaviour
+    {
+        /// <summary>
+        /// Request a new screen using a prefab name
+        /// </summary>
+        /// <param name="screenPrefab">Screen prefab to switch to</param>
+        public void SetScreen(GameObject screenPrefab)
+        {
+            this.SetScreen(screenPrefab.name);
+        }
+
+        /// <summary>
+        /// Request a new screen directly through a name
+        /// </summary>
+        /// <param name="name">Name of new screen to display</param>
+        public void SetScreen(string name)
+        {
+            UIManager.RequestNewScreen(this, name);
+        }
+    }
+}

--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -2,6 +2,9 @@
 
 namespace PropHunt.UI
 {
+    /// <summary>
+    /// Simple class to abstract commands to change UI for a menu screen
+    /// </summary>
     public class MenuController : MonoBehaviour
     {
         /// <summary>

--- a/Assets/Scripts/UI/MenuController.cs.meta
+++ b/Assets/Scripts/UI/MenuController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ee52dadfaa455148a69c5d23ea72b37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -1,10 +1,169 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace PropHunt.UI
 {
+    /// <summary>
+    /// Class to hold arguments for showing a new screen
+    /// </summary>
+    public class RequestScreenChangeEventArgs : EventArgs
+    {
+        /// <summary>
+        /// String identifier for the new screen to load
+        /// </summary>
+        public string newScreen { get; set; }
+    }
+
+    /// <summary>
+    /// Class to hold screen change in state
+    /// </summary>
+    public class ScreenChangeEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Name of the previous screen shown
+        /// </summary>
+        public string oldScreen { get; set; }
+        
+        /// <summary>
+        /// Name of the new screen being changed to
+        /// </summary>
+        public string newScreen { get; set; }
+    }
+
+    /// <summary>
+    /// Class to manager various UI Screens
+    /// </summary>
     public class UIManager : MonoBehaviour
     {
-        
+        /// <summary>
+        /// Events for requesting a screen change
+        /// </summary>
+        public static event EventHandler<RequestScreenChangeEventArgs> RequestScreenChange;
+
+        /// <summary>
+        /// Events for when a screen change has ocurred
+        /// </summary>
+        public static event EventHandler<ScreenChangeEventArgs> ScreenChangeOccur;
+
+        /// <summary>
+        /// Various screens to add into the scene
+        /// </summary>
+        public List<Canvas> screenPrefabs;
+
+        /// <summary>
+        /// Index of the first screen to show
+        /// </summary>
+        public int initialScreen;
+
+        /// <summary>
+        /// Name of the current screen being displayed
+        /// </summary>
+        public string CurrentScreen { get; private set; }
+
+        /// <summary>
+        /// Lookup table of name of screen to screen being shown
+        /// </summary>
+        private Dictionary<string, GameObject> screenLookup;
+
+        public void Start()
+        {
+            if (this.screenPrefabs.Count == 0)
+            {
+                UnityEngine.Debug.Log("No valid screens to display for UIManager");
+                return;
+            }
+
+            if (this.initialScreen < 0 || this.initialScreen > this.screenPrefabs.Count)
+            {
+                UnityEngine.Debug.Log($"Initial Screen {this.initialScreen} invalid, defaulting to screen {0}");
+                this.initialScreen = 0;
+            }
+
+            // Setup dictionary of screens
+            this.screenLookup = new Dictionary<string, GameObject>();
+            for(int idx = 0; idx < this.screenPrefabs.Count; idx++)
+            {
+                string screenName = screenPrefabs[idx].name;
+                // instantiate a copy of each screen and set all to disabled except current screen
+                GameObject screen = GameObject.Instantiate(screenPrefabs[idx].gameObject);
+                // Set object parent to this for more organized hierarchy
+                screen.transform.SetParent(this.transform, worldPositionStays : false);
+                this.screenLookup[screenName] = screen;
+                if (idx == this.initialScreen)
+                {
+                    this.CurrentScreen = screenName;
+                    this.screenLookup[screenName].SetActive(true);
+                }
+                else
+                {
+                    this.screenLookup[screenName].SetActive(false);
+                }
+            }
+
+            // Setup listening to event queue
+            RequestScreenChange += this.HandleScreenRequest;
+        }
+
+        public void OnDisable()
+        {
+            RequestScreenChange -= this.HandleScreenRequest;
+        }
+
+        /// <summary>
+        /// Handle a request to change screens
+        /// </summary>
+        /// <param name="sender">sender of the event</param>
+        /// <param name="eventArgs">arguments of screen change</param>
+        public void HandleScreenRequest(object sender, RequestScreenChangeEventArgs eventArgs)
+        {
+            this.SetScreen(eventArgs.newScreen);
+        }
+
+        /// <summary>
+        /// Sets this screen to be displayed
+        /// </summary>
+        /// <param name="screenName">Name of the screen to display</param>
+        public void SetScreen(string screenName)
+        {
+            if (!this.screenLookup.ContainsKey(screenName))
+            {
+                UnityEngine.Debug.Log($"Screen name {screenName} not recognized as new screen");
+                return;
+            }
+            if (screenName == this.CurrentScreen)
+            {
+                // no change, do nothing
+                return;
+            }
+
+            GameObject currentlyDisplayed = this.screenLookup[this.CurrentScreen];
+            GameObject newDisplay = this.screenLookup[screenName];
+
+            currentlyDisplayed.SetActive(false);
+            newDisplay.SetActive(true);
+
+            ScreenChangeEventArgs changeEvent = new ScreenChangeEventArgs();
+            changeEvent.oldScreen = this.CurrentScreen;
+            changeEvent.newScreen = screenName;
+
+            this.CurrentScreen = screenName;
+            
+            // invoke screen change event
+            ScreenChangeOccur?.Invoke(this, changeEvent);
+        }
+
+        /// <summary>
+        /// Requests a new screen to be shown
+        /// </summary>
+        /// <param name="sender">Object sending the event</param>
+        /// <param name="name">Name of new screen to show</param>
+        public static void RequestNewScreen(object sender, string name)
+        {
+            RequestScreenChangeEventArgs request = new RequestScreenChangeEventArgs();
+            request.newScreen = name;
+            UIManager.RequestScreenChange?.Invoke(sender, request);
+        }
     }
 }
 

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace PropHunt.UI
+{
+    public class UIManager : MonoBehaviour
+    {
+        
+    }
+}
+

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -100,7 +100,10 @@ namespace PropHunt.UI
                     this.screenLookup[screenName].SetActive(false);
                 }
             }
+        }
 
+        public void OnEnable()
+        {
             // Setup listening to event queue
             RequestScreenChange += this.HandleScreenRequest;
         }

--- a/Assets/Scripts/UI/UIManager.cs.meta
+++ b/Assets/Scripts/UI/UIManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb7b9320169ee8d469ea7ba143194c4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Created basic in game menu using a simple static system and event handler.

This works completely on the client side. It uses [Assets\Scripts\Client\Systems\MenuManagerSystem.cs](https://github.com/nicholas-maltbie/PropHunt/blob/feature/InGameMenu/Assets/Scripts/Client/Systems/MenuManagerSystem.cs) to parse player input to open/close the menu with the player's input. The file [Assets\Scripts\UI\UIManager.cs]((https://github.com/nicholas-maltbie/PropHunt/blob/feature/InGameMenu/Assets/Scripts/UI/UIManager.cs)) contains a MonoBehaviour that handles changing between different screens. Currently there are only two screens. 

There is an event system that handles requesting changes in screen and listening to changes to screens. The reason this is abstracted to an event system is because many things could change the screen (keyboard, gamepad, button press, UI element, in game event) and that is tied to locking the user input (when the menu is open the user input needs to be locked). This system allows for the user input to be locked when the UI menu is open, and unlocked when the normal player HUD is open. This could be improved to fully use ECS to manage events but since this event should never happen more than once per frame the improvement in performance would be marginal and not justify the increased complexity (a one frame lag in the UI menu change or player input is alright for now).

The other files were changed to accommodate this new system and mono behavior. 

# How Has This Been Tested?

This can be tested by opening the sample scene and pressing the "cancel" (escape) key to open the menu. This will bring up the two buttons (only one of which does anything right now). And then this can be closed by either pressing the "cancel" button or by clicking the "back to game" button. 

The "disconnect" button is just a placeholder for leaving the game.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~New and existing unit tests pass locally with my changes~~

(No testing framework setup yet so ignore the last two)

Closes #17 
