### PR TITLE
Removed SampleImages Folder to Save Space

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -65,20 +65,20 @@ git-lfs --version
 After you have downloaded the git repo, launch unity hub and navigate to the `Projects` section on the
 menu on the left half of the screen. 
 
-![Unity Hub Projects Screen with highlights around the projects and add buttons](SampleImages/SetupGuide/UnityProjects.png)
+![Unity Hub Projects Screen with highlights around the projects and add buttons](https://drive.google.com/uc?export=view&id=1hJgtwej_AGCw9ASVkFL6hH-VzF3Mopya)
 
 From this file menu, navigate to the folder where the
 project has been downloaded. For example 
 `~/projects/PropHunt`. Then hit the `Open` 
 button in the file selector.
 
-![Selecting Project from file selector](SampleImages/SetupGuide/UnityLoad.png)
+![Selecting Project from file selector](https://drive.google.com/uc?export=view&id=1XbxAoZ4ISadUDGPs6bxxQUUxYnxXlLOa)
 
 After the environment has a chance to load, the project 
 should be listed in the projects area as shown in the image
 below.
 
-![Everything setup and good to go](SampleImages/SetupGuide/UnityComplete.png)
+![Everything setup and good to go](https://drive.google.com/uc?export=view&id=14u9Wy9Z85XrhbUmrWNuUaqdZ5B00TMUX)
 
 # 5. Coding Environment
 
@@ -101,9 +101,9 @@ To enable the .NET 4.x scripting runtime, take the following steps:
 1. Open PlayerSettings in the Unity Inspector by selecting `Edit > Project Settings > Player > Other Settings`.
 2. Under the Configuration heading, click the Scripting Runtime Version dropdown and select .NET 4.x Equivalent. You will be prompted to restart Unity.
 
-![Navigating to menu](SampleImages/SetupGuide/SetupDotNet4.x.png)
+![Navigating to menu](https://drive.google.com/uc?export=view&id=1QnLfHdX3HC27FXjjVuFf3ASqezcALpgL)
 
-![Menu to setup changes](SampleImages/SetupGuide/vstu_scripting-runtime-version.png)
+![Menu to setup changes](https://drive.google.com/uc?export=view&id=15EWdxaH7x5OWRXiQlcwUo-2q-8WKn0jv)
 
 From Microsoft's article ([Unity to .NET 4.x](https://docs.microsoft.com/en-us/visualstudio/cross-platform/unity-scripting-upgrade?view=vs-2019))
 
@@ -135,12 +135,12 @@ Edit > Preferences > External Tools > External Script Editor
 1. Edit (Top left of screen)
 2. Preferences (Lower section of the edit menu)
 
-![Edit > Preferences view in Unity](SampleImages/SetupGuide/EditPreferences.png)
+![Edit > Preferences view in Unity](https://drive.google.com/uc?export=view&id=18hnXNEX87WM0cpGjyG8r2pI5xMUECF5z)
 
 3. External Tools (Lower section of sub menus for Preferences)
 4. Select Visual Studio Code from the External Script Editor
 
-![Preferences > External Tools > Select External](SampleImages/SetupGuide/SelectVSCode.png)
+![Preferences > External Tools > Select External](https://drive.google.com/uc?export=view&id=1Wx_d1u-XSBQn6AX_un7sqbrUq_6bXT__)
 
 # 8. VS Code Extensions
 

--- a/SampleImages/Demo/disconnect.gif
+++ b/SampleImages/Demo/disconnect.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b10ec9c2d4337bf28578f6f2be915825645817a4fb75e334708c3984f4a17e3
-size 366779

--- a/SampleImages/Demo/kinematic-cc.gif
+++ b/SampleImages/Demo/kinematic-cc.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29ee7f1fd43bbafa028ed04c216a42f7191327fb481d5358b1acb687912fe1a2
-size 20774070

--- a/SampleImages/Demo/push.gif
+++ b/SampleImages/Demo/push.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd8f64e02f6f026a0d70dd74097a682c6b89f975adfb4e6c01bdc742d38b2a5c
-size 2868040

--- a/SampleImages/SetupGuide/EditPreferences.png
+++ b/SampleImages/SetupGuide/EditPreferences.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41921c1dd3971c2cb952408d13024fc633ff26eeedc47b86cd4abd4e033da432
-size 41386

--- a/SampleImages/SetupGuide/SelectVSCode.png
+++ b/SampleImages/SetupGuide/SelectVSCode.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5703797d1a5031ea18f7bf8d3f3260627b60965bcdfc6e8dd69446ecb587b12
-size 37838

--- a/SampleImages/SetupGuide/SetupDotNet4.x.png
+++ b/SampleImages/SetupGuide/SetupDotNet4.x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0baa965ea19289af4c58c0ab2275c114440ad37a6dc1a49b4368b6dee7ac525
-size 143573

--- a/SampleImages/SetupGuide/UnityComplete.png
+++ b/SampleImages/SetupGuide/UnityComplete.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:042ae336202e565f9ab9f3a1cf0285136b73d7efceacc29f0b8b0b2e7746c66b
-size 58298

--- a/SampleImages/SetupGuide/UnityLoad.png
+++ b/SampleImages/SetupGuide/UnityLoad.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f289504b69dbbe49a32d3b15dbdac0e8124ecf739dc07266efa3495f519f0cc0
-size 71036

--- a/SampleImages/SetupGuide/UnityProjects.png
+++ b/SampleImages/SetupGuide/UnityProjects.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b635c6a1c4dd86ffdb84e2f90ca8ea9b4cd32f9d05f70cd010c1963b0fdb2bc5
-size 41031

--- a/SampleImages/SetupGuide/vstu_scripting-runtime-version.png
+++ b/SampleImages/SetupGuide/vstu_scripting-runtime-version.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cdb21c0ec975fe53fd03c898aa0257d5a70a44de8d2e6910b1557acb936934ae
-size 17027


### PR DESCRIPTION
# Description

Removed sample images folder to save git lfs space and bandwidth. Shifted all resources to this public Google Drive folder https://drive.google.com/drive/folders/1lH766kWJsMs4qIU-oueZykXW9GuNbisk?usp=sharing

# How Has This Been Tested?

Tested feature by checking visual of readme (only folder that used files)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~New and existing unit tests pass locally with my changes~~

(No testing framework setup yet so ignore the last two)
