### PR TITLE
Added coverage generation to unity tests

### DIFF
--- a/.github/disabled-workflows/build-dev.yml
+++ b/.github/disabled-workflows/build-dev.yml
@@ -40,7 +40,6 @@ jobs:
           key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}-v.1.0
           restore-keys: |
             Library-${{ matrix.platform }}-
-            Library-
 
       - name: Cache git lfs
         uses: actions/cache@v2

--- a/.github/disabled-workflows/build-dev.yml
+++ b/.github/disabled-workflows/build-dev.yml
@@ -37,7 +37,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
+<<<<<<< HEAD
           key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}-v.1.0
+=======
+          key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}
+>>>>>>> Corrected cache path to use '/' instead of '\'
           restore-keys: |
             Library-${{ matrix.platform }}-
             Library-

--- a/.github/disabled-workflows/build-dev.yml
+++ b/.github/disabled-workflows/build-dev.yml
@@ -37,11 +37,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
-<<<<<<< HEAD
           key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}-v.1.0
-=======
-          key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}
->>>>>>> Corrected cache path to use '/' instead of '\'
           restore-keys: |
             Library-${{ matrix.platform }}-
             Library-

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -18,10 +18,10 @@ jobs:
         unityVersion:
           - 2019.4.0f1
         platform:
-          - OSX       # Build a macOS standalone (Intel 64-bit).
-          - Windows   # Build a Windows standalone.
-          - Windows64 # Build a Windows 64-bit standalone.
-          - Linux64   # Build a Linux 64-bit standalone.
+          - StandaloneOSX       # Build a macOS standalone (Intel 64-bit).
+          - StandaloneWindows   # Build a Windows standalone.
+          - StandaloneWindows64 # Build a Windows 64-bit standalone.
+          - StandaloneLinux64   # Build a Linux 64-bit standalone.
         buildType:
           - Client
           - Server
@@ -40,7 +40,6 @@ jobs:
           key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}-v.1.0
           restore-keys: |
             Library-${{ matrix.platform }}-
-            Library-
 
       - name: Cache git lfs
         uses: actions/cache@v2
@@ -58,9 +57,11 @@ jobs:
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
-          buildMethod: EditorNamespace.ProdBuilder.${{ matrix.buildType }}_${{ matrix.platform }}
+          targetPlatform: ${{ matrix.platform }}
+          buildMethod: EditorNamespace.Builder.BuildProject	
+          customParameters: -buildType ${{ matrix.buildType }}
 
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.platform }}-${{ matrix.buildType }}
-          path: Builds/*
+          path: build

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -58,7 +58,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.platform }}
-          buildMethod: EditorNamespace.Builder.BuildProject	
+          buildMethod: EditorNamespace.Builder.BuildProject
           customParameters: -buildType ${{ matrix.buildType }}
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -37,7 +37,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
+<<<<<<< HEAD
           key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}-v.1.0
+=======
+          key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}
+>>>>>>> Corrected cache path to use '/' instead of '\'
           restore-keys: |
             Library-${{ matrix.platform }}-
             Library-

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -18,10 +18,10 @@ jobs:
         unityVersion:
           - 2019.4.0f1
         platform:
-          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
-          - StandaloneWindows # Build a Windows standalone.
-          - StandaloneWindows64 # Build a Windows 64-bit standalone.
-          - StandaloneLinux64 # Build a Linux 64-bit standalone.
+          - OSX       # Build a macOS standalone (Intel 64-bit).
+          - Windows   # Build a Windows standalone.
+          - Windows64 # Build a Windows 64-bit standalone.
+          - Linux64   # Build a Linux 64-bit standalone.
         buildType:
           - Client
           - Server
@@ -58,11 +58,9 @@ jobs:
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
-          targetPlatform: ${{ matrix.platform }}
-          buildMethod: EditorNamespace.Builder.BuildProject
-          customParameters: -buildType ${{ matrix.buildType }}
+          buildMethod: EditorNamespace.ProdBuilder.${{ matrix.buildType }}_${{ matrix.platform }}
 
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.platform }}-${{ matrix.buildType }}
-          path: build
+          path: Builds/*

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -37,11 +37,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
-<<<<<<< HEAD
           key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}-v.1.0
-=======
-          key: Library-${{ matrix.platform }}-${{ hashFiles('Packages/manifest.json') }}
->>>>>>> Corrected cache path to use '/' instead of '\'
           restore-keys: |
             Library-${{ matrix.platform }}-
             Library-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,10 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
-          customParameters: -enableCodeCoverage -coverageResultsPath ${{ matrix.testMode }}-artifacts -coverageOptions generateHtmlReport;generateBadgeReport
+          customParameters: |
+            -enableCodeCoverage
+            -coverageResultsPath ${{ matrix.testMode }}-artifacts
+            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
             Test Coverage Results for ${{ matrix.testMode }}:
             Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}%
             Branch Coverage: ${{ env.BRANCH_COVERAGE }}%
-            Link to run results: [https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}](https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }})
+            Link to run results: [https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
-          key: Library-${{ matrix.platform }}-${{ hashFiles('Packages\manifest.json') }}
+          key: Library-${{ hashFiles('Packages\manifest.json') }}
           restore-keys: |
-            Library-${{ matrix.platform }}-
             Library-
 
       - name: Cache git lfs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,3 +66,31 @@ jobs:
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
+      
+      - name: sequenceCoverage
+        uses: mavrosxristoforos/get-xml-info@1.0
+        with:
+          xml-file: ${{ matrix.testMode }}-artifacts/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
+          xpath: '/CoverageSession/Summary@sequenceCoverage'
+      
+      - name: branchCoverage
+        uses: mavrosxristoforos/get-xml-info@1.0
+        with:
+          xml-file: ${{ matrix.testMode }}-artifacts/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
+          xpath: '/CoverageSession/Summary@branchCoverage'
+      
+      - uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.info }}
+            Branch Coverage: ${{ steps.branchCoverage.outputs.info }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
+          allow-repeats: false # This is the default
+      
+      - name: Assert Coverage
+        run: |
+          python3 -c "assert ${{ steps.branchCoverage.outputs.info }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.info }}%'"
+          python3 -c "assert ${{ steps.sequenceCoverage.outputs.info }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.info }}%'"
+      
+      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           customParameters: |
             -enableCodeCoverage
             -coverageResultsPath ${{ matrix.testMode }}-artifacts
-            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*,-EditModeTests,-Assembly*
+            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*,-EditModeTests
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
             Test Coverage Results for ${{ matrix.testMode }}:
             Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}%
             Branch Coverage: ${{ env.BRANCH_COVERAGE }}%
-            Link to run results: [https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+            Link to run results: [https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,13 +71,11 @@ jobs:
         run: |
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
       
-      - run: cat "${{ env.COVERAGE_FILE }}"
-      
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
           xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '//Summary[@sequenceCoverage]'
+          xpath: '/CoverageSession/Summary/@sequenceCoverage'
       
       - name: branchCoverage
         uses: mavrosxristoforos/get-xml-info@1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,10 +57,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
-          customParameters: |
-            -enableCodeCoverage
-            -coverageResultsPath ${{ matrix.testMode }}-artifacts
-            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*,-EditModeTests
+          customParameters: -enableCodeCoverage -coverageResultsPath ${{ matrix.testMode }}-artifacts -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*,-EditModeTests
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,10 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
-          customParameters: -enableCodeCoverage -coverageResultsPath ${{ matrix.testMode }}-artifacts -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:-PropHunt.Test*,-EditModeTests,-Assembly*
+          customParameters: |
+            -enableCodeCoverage
+            -coverageResultsPath ${{ matrix.testMode }}-artifacts
+            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:-PropHunt.Test*,-EditModeTests,-Assembly*;pathFilters:-*/Assets/Scripts/*Generated/*
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
         unityVersion:
           - 2019.4.0f1
         testMode:
-          - PlayMode
-          - EditMode
+          # - PlayMode
+          - editmode
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
           xml-file: ${{ steps.tests.outputs.artifactsPath }}/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
-          xpath: '/CoverageSession/Summary[0]@branchCoverage'
+          xpath: '/CoverageSession/Summary[1]@branchCoverage'
       
       - uses: mshick/add-pr-comment@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: "find . -name 'TestCoverageResults_0000.xml'"
+          xml-file: "$(find . -name 'TestCoverageResults_0000.xml')"
           xpath: '/CoverageSession/Summary@sequenceCoverage'
       
       - name: branchCoverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,22 +72,29 @@ jobs:
         run: |
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
       
-      - name: Select Coverage
-        run: |
-          echo ::set-env name=SEQUENCE_COVERAGE::$(cat ${{ env.COVERAGE_FILE }} | xpath '/CoverageSession/Summary/@sequenceCoverage')
-          echo ::set-env name=BRANCH_COVERAGE::$(cat ${{ env.COVERAGE_FILE }} | xpath '/CoverageSession/Summary/@sequenceCoverage')
+      - name: sequenceCoverage
+        uses: QwerMike/xpath-action@v1
+        with:
+          filename: "${{ env.COVERAGE_FILE }}"
+          expression: '/CoverageSession/Summary/@sequenceCoverage'
+      
+      - name: branchCoverage
+        uses: QwerMike/xpath-action@v1
+        with:
+          filename: "${{ env.COVERAGE_FILE }}"
+          expression: '/CoverageSession/Summary/@branchCoverage'
       
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}
-            Branch Coverage: ${{ env.BRANCH_COVERAGE }}
+            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.result }}
+            Branch Coverage: ${{ steps.branchCoverage.outputs.result }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
       
       - name: Assert Coverage
         run: |
-          python3 -c "assert ${{ env.SEQUENCE_COVERAGE }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ env.SEQUENCE_COVERAGE }}%'"
-          python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ env.BRANCH_COVERAGE }}%'"
+          python3 -c "assert ${{ steps.sequenceCoverage.outputs.result }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.result }}%'"
+          python3 -c "assert ${{ steps.branchCoverage.outputs.result }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.result }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,7 @@ jobs:
       - name: findCoverage
         run: |
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
+          cat "${{ env.COVERAGE_FILE }}"
       
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
@@ -80,7 +81,7 @@ jobs:
       - name: branchCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: ${{ steps.tests.outputs.artifactsPath }}/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
+          xml-file: "${{ env.COVERAGE_FILE }}"
           xpath: '/CoverageSession/Summary[1]@branchCoverage'
       
       - uses: mshick/add-pr-comment@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,8 @@ jobs:
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
       
-      - name: Assert Coverage
-        run: |
-          python3 -c "assert ${{ env.SEQUENCE_COVERAGE }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ env.SEQUENCE_COVERAGE }}%'"
-          python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ env.BRANCH_COVERAGE }}%'"
+      # Skip assert coverage step for now
+      # - name: Assert Coverage
+      #   run: |
+      #     python3 -c "assert ${{ env.SEQUENCE_COVERAGE }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ env.SEQUENCE_COVERAGE }}%'"
+      #     python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ env.BRANCH_COVERAGE }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,8 +88,8 @@ jobs:
       
       - name: Parse Coverage
         run: |
-          echo ::set-env name=SEQUENCE_COVERAGE::$(cut -d "=" -f2- <<< steps.sequenceCoverage.outputs.result)
-          echo ::set-env name=BRANCH_COVERAGE::$(cut -d "=" -f2- <<< steps.branchCoverage.outputs.result)
+          echo ::set-env name=SEQUENCE_COVERAGE::$(cut -d "=" -f2- <<< ${{ steps.sequenceCoverage.outputs.result }})
+          echo ::set-env name=BRANCH_COVERAGE::$(cut -d "=" -f2- <<< ${{ steps.branchCoverage.outputs.result }})
       
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
         uses: QwerMike/xpath-action@v1
         with:
           filename: "${{ env.COVERAGE_FILE }}"
-          filename: '/CoverageSession/Summary/@branchCoverage'
+          expression: '/CoverageSession/Summary/@branchCoverage'
       
       - uses: mshick/add-pr-comment@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
+            Test Coverage Results:
             Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}
             Branch Coverage: ${{ env.BRANCH_COVERAGE }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,37 +62,32 @@ jobs:
             -coverageResultsPath ${{ matrix.testMode }}-artifacts
             -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:-PropHunt.Test*,-EditModeTests,-Assembly*;pathFilters:-*/Assets/Scripts/*Generated/*
 
-      - uses: actions/upload-artifact@v1
+      - name: Upload Results
+        uses: actions/upload-artifact@v1
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
       
-      - name: findCoverage
+      - name: Find Coverage
         run: |
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
       
-      - name: sequenceCoverage
-        uses: QwerMike/xpath-action@v1
-        with:
-          filename: "${{ env.COVERAGE_FILE }}"
-          expression: '/CoverageSession/Summary/@sequenceCoverage'
+      - name: Select Coverage
+        run: |
+          echo ::set-env name=SEQUENCE_COVERAGE::$(cat ${{ env.COVERAGE_FILE }} | xpath '/CoverageSession/Summary/@sequenceCoverage')
+          echo ::set-env name=BRANCH_COVERAGE::$(cat ${{ env.COVERAGE_FILE }} | xpath '/CoverageSession/Summary/@sequenceCoverage')
       
-      - name: branchCoverage
-        uses: QwerMike/xpath-action@v1
-        with:
-          filename: "${{ env.COVERAGE_FILE }}"
-          expression: '/CoverageSession/Summary/@branchCoverage'
-      
-      - uses: mshick/add-pr-comment@v1
+      - name: Add PR Comment
+        uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.info }}
-            Branch Coverage: ${{ steps.branchCoverage.outputs.info }}
+            Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}
+            Branch Coverage: ${{ env.BRANCH_COVERAGE }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
       
       - name: Assert Coverage
         run: |
-          python3 -c "assert ${{ steps.branchCoverage.outputs.info }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.info }}%'"
-          python3 -c "assert ${{ steps.sequenceCoverage.outputs.info }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.info }}%'"
+          python3 -c "assert ${{ env.SEQUENCE_COVERAGE }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ env.SEQUENCE_COVERAGE }}%'"
+          python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ BRANCH_COVERAGE }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,19 +67,19 @@ jobs:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
       
-      - run: ls ${{ matrix.testMode }}-artifactsPath
+      - run: ls ${{ steps.tests.outputs.artifactsPath }}
       - run: find . -name "TestCoverageResults_0000.xml"
       
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: ${{ matrix.testMode }}-artifacts/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
+          xml-file: ${{ steps.tests.outputs.artifactsPath }}/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
           xpath: '/CoverageSession/Summary@sequenceCoverage'
       
       - name: branchCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: ${{ matrix.testMode }}-artifacts/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
+          xml-file: ${{ steps.tests.outputs.artifactsPath }}/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
           xpath: '/CoverageSession/Summary@branchCoverage'
       
       - uses: mshick/add-pr-comment@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
-          key: Library-${{ matrix.platform }}
+          key: Library-${{ matrix.platform }}-${{ hashFiles('Packages\manifest.json') }}
           restore-keys: |
-            Library-${{ matrix.projectPath }}-
+            Library-${{ matrix.platform }}-
             Library-
 
       - name: Cache git lfs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
-          customParameters: -enableCodeCoverage -coverageResultsPath ${{ matrix.testMode }}-artifacts -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*,-EditModeTests
+          customParameters: -enableCodeCoverage -coverageResultsPath ${{ matrix.testMode }}-artifacts -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:-PropHunt.Test*,-EditModeTests,-Assembly*
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,9 @@ jobs:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
       
+      - run: ls ${{ matrix.testMode }}-artifactsPath
+      - run: find . -name "TestCoverageResults_0000.xml"
+      
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         unityVersion:
           - 2019.4.0f1
         testMode:
-          # - PlayMode
+          - PlayMode
           - EditMode
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: ${{ steps.tests.outputs.artifactsPath }}/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
+          xml-file: "find . -name 'TestCoverageResults_0000.xml'"
           xpath: '/CoverageSession/Summary@sequenceCoverage'
       
       - name: branchCoverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
-          key: Library-Tests-${{ hashFiles('Packages\manifest.json') }}
+          key: Library-Tests-${{ hashFiles('Packages/manifest.json') }}
           restore-keys: |
             Library-Tests-
             Library-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: Library
-          key: Library-${{ hashFiles('Packages\manifest.json') }}
+          key: Library-Tests-${{ hashFiles('Packages\manifest.json') }}
           restore-keys: |
+            Library-Tests-
             Library-
 
       - name: Cache git lfs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,9 +95,10 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Test Coverage Results:
-            Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}
-            Branch Coverage: ${{ env.BRANCH_COVERAGE }}
+            Test Coverage Results for ${{ matrix.testMode }}:
+            Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}%
+            Branch Coverage: ${{ env.BRANCH_COVERAGE }}%
+            Link to run results: [https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}](https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }})
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
         unityVersion:
           - 2019.4.0f1
         testMode:
-          - playmode
-          - editmode
+          # - PlayMode
+          - EditMode
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,8 +88,8 @@ jobs:
       
       - name: Parse Coverage
         run: |
-        echo ::set-env name=SEQUENCE_COVERAGE::$(cut -d "=" -f2- <<< steps.sequenceCoverage.outputs.result)
-        echo ::set-env name=BRANCH_COVERAGE::$(cut -d "=" -f2- <<< steps.branchCoverage.outputs.result)
+          echo ::set-env name=SEQUENCE_COVERAGE::$(cut -d "=" -f2- <<< steps.sequenceCoverage.outputs.result)
+          echo ::set-env name=BRANCH_COVERAGE::$(cut -d "=" -f2- <<< steps.branchCoverage.outputs.result)
       
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
       
       - name: findCoverage
         run: |
-          echo ::set-env name=COVERAGE_FILE::$(find . -name "TestCoverageResults_0000.xml")
+          echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
       
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,5 +92,3 @@ jobs:
         run: |
           python3 -c "assert ${{ steps.branchCoverage.outputs.info }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.info }}%'"
           python3 -c "assert ${{ steps.sequenceCoverage.outputs.info }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.info }}%'"
-      
-      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,17 +86,22 @@ jobs:
           filename: "${{ env.COVERAGE_FILE }}"
           expression: '//CoverageSession/Summary/@branchCoverage'
       
+      - name: Parse Coverage
+        run: |
+        echo ::set-env name=SEQUENCE_COVERAGE::$(cut -d "=" -f2- <<< steps.sequenceCoverage.outputs.result)
+        echo ::set-env name=BRANCH_COVERAGE::$(cut -d "=" -f2- <<< steps.branchCoverage.outputs.result)
+      
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.result }}
-            Branch Coverage: ${{ steps.branchCoverage.outputs.result }}
+            Sequence Coverage: ${{ env.SEQUENCE_COVERAGE }}
+            Branch Coverage: ${{ env.BRANCH_COVERAGE }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
       
       - name: Assert Coverage
         run: |
-          python3 -c "assert ${{ steps.sequenceCoverage.outputs.result }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.result }}%'"
-          python3 -c "assert ${{ steps.branchCoverage.outputs.result }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.result }}%'"
+          python3 -c "assert ${{ env.SEQUENCE_COVERAGE }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ env.SEQUENCE_COVERAGE }}%'"
+          python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ env.BRANCH_COVERAGE }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
+          customParameters: -enableCodeCoverage -coverageResultsPath ${{ matrix.testMode }}-artifacts -coverageOptions generateHtmlReport;generateBadgeReport
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
           xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '/CoverageSession/Summary@sequenceCoverage'
+          xpath: '/CoverageSession/Summary[@sequenceCoverage]'
       
       - name: branchCoverage
         uses: mavrosxristoforos/get-xml-info@1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,15 +76,15 @@ jobs:
         id: sequenceCoverage
         uses: QwerMike/xpath-action@v1
         with:
-          xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '//CoverageSession/Summary/@sequenceCoverage'
+          filename: "${{ env.COVERAGE_FILE }}"
+          expression: '//CoverageSession/Summary/@sequenceCoverage'
       
       - name: Branch Coverage
         id: branchCoverage
         uses: QwerMike/xpath-action@v1
         with:
-          xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '//CoverageSession/Summary/@branchCoverage'
+          filename: "${{ env.COVERAGE_FILE }}"
+          expression: '//CoverageSession/Summary/@branchCoverage'
       
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,29 +74,29 @@ jobs:
       
       - name: Sequence Coverage
         id: sequenceCoverage
-        uses: mavrosxristoforos/get-xml-info@1.0
+        uses: QwerMike/xpath-action@v1
         with:
           xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '/CoverageSession/Summary/@sequenceCoverage'
+          xpath: '//CoverageSession/Summary/@sequenceCoverage'
       
       - name: Branch Coverage
         id: branchCoverage
-        uses: mavrosxristoforos/get-xml-info@1.0
+        uses: QwerMike/xpath-action@v1
         with:
           xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '/CoverageSession/Summary/@branchCoverage'
+          xpath: '//CoverageSession/Summary/@branchCoverage'
       
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.info }}
-            Branch Coverage: ${{ steps.branchCoverage.outputs.info }}
+            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.result }}
+            Branch Coverage: ${{ steps.branchCoverage.outputs.result }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
       
       - name: Assert Coverage
         run: |
-          python3 -c "assert ${{ steps.sequenceCoverage.outputs.info }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.info }}%'"
-          python3 -c "assert ${{ steps.branchCoverage.outputs.info }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.info }}%'"
+          python3 -c "assert ${{ steps.sequenceCoverage.outputs.result }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.result }}%'"
+          python3 -c "assert ${{ steps.branchCoverage.outputs.result }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.result }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,13 +67,13 @@ jobs:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
       
-      - run: ls ${{ steps.tests.outputs.artifactsPath }}
-      - run: find . -name "TestCoverageResults_0000.xml"
+      - name: findCoverage
+        run: find . -name "TestCoverageResults_0000.xml"
       
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: "$(find . -name 'TestCoverageResults_0000.xml')"
+          xml-file: "${{ steps.findCoverage.output }}"
           xpath: '/CoverageSession/Summary@sequenceCoverage'
       
       - name: branchCoverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,8 @@ jobs:
       - name: findCoverage
         run: |
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
-          cat "${{ env.COVERAGE_FILE }}"
+      
+      - run: cat "${{ env.COVERAGE_FILE }}"
       
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,4 +90,4 @@ jobs:
       - name: Assert Coverage
         run: |
           python3 -c "assert ${{ env.SEQUENCE_COVERAGE }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ env.SEQUENCE_COVERAGE }}%'"
-          python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ BRANCH_COVERAGE }}%'"
+          python3 -c "assert ${{ env.BRANCH_COVERAGE }} >= 95, 'Branch coverage must be at least 95%, is only ${{ env.BRANCH_COVERAGE }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
           xml-file: ${{ steps.tests.outputs.artifactsPath }}/workspace-opencov/${{ matrix.testMode }}/TestCoverageResults_0000.xml
-          xpath: '/CoverageSession/Summary@branchCoverage'
+          xpath: '/CoverageSession/Summary[0]@branchCoverage'
       
       - uses: mshick/add-pr-comment@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
           xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '/CoverageSession/Summary[@sequenceCoverage]'
+          xpath: '//Summary[@sequenceCoverage]'
       
       - name: branchCoverage
         uses: mavrosxristoforos/get-xml-info@1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,29 +72,31 @@ jobs:
         run: |
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
       
-      - name: sequenceCoverage
-        uses: QwerMike/xpath-action@v1
+      - name: Sequence Coverage
+        id: sequenceCoverage
+        uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          filename: "${{ env.COVERAGE_FILE }}"
-          expression: '/CoverageSession/Summary/@sequenceCoverage'
+          xml-file: "${{ env.COVERAGE_FILE }}"
+          xpath: '/CoverageSession/Summary/@sequenceCoverage'
       
-      - name: branchCoverage
-        uses: QwerMike/xpath-action@v1
+      - name: Branch Coverage
+        id: branchCoverage
+        uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          filename: "${{ env.COVERAGE_FILE }}"
-          expression: '/CoverageSession/Summary/@branchCoverage'
+          xml-file: "${{ env.COVERAGE_FILE }}"
+          xpath: '/CoverageSession/Summary/@branchCoverage'
       
       - name: Add PR Comment
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.result }}
-            Branch Coverage: ${{ steps.branchCoverage.outputs.result }}
+            Sequence Coverage: ${{ steps.sequenceCoverage.outputs.info }}
+            Branch Coverage: ${{ steps.branchCoverage.outputs.info }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default
       
       - name: Assert Coverage
         run: |
-          python3 -c "assert ${{ steps.sequenceCoverage.outputs.result }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.result }}%'"
-          python3 -c "assert ${{ steps.branchCoverage.outputs.result }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.result }}%'"
+          python3 -c "assert ${{ steps.sequenceCoverage.outputs.info }} >= 95, 'Sequence coverage must be at least 95%, is only ${{ steps.sequenceCoverage.outputs.info }}%'"
+          python3 -c "assert ${{ steps.branchCoverage.outputs.info }} >= 95, 'Branch coverage must be at least 95%, is only ${{ steps.branchCoverage.outputs.info }}%'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           customParameters: |
             -enableCodeCoverage
             -coverageResultsPath ${{ matrix.testMode }}-artifacts
-            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*
+            -coverageOptions generateHtmlReport;generateBadgeReport;assemblyFilters:+PropHunt.*,-PropHunt.Test*,-EditModeTests,-Assembly*
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,16 +72,16 @@ jobs:
           echo ::set-env name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.artifactsPath }} -name "TestCoverageResults_0000.xml")
       
       - name: sequenceCoverage
-        uses: mavrosxristoforos/get-xml-info@1.0
+        uses: QwerMike/xpath-action@v1
         with:
-          xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '/CoverageSession/Summary/@sequenceCoverage'
+          filename: "${{ env.COVERAGE_FILE }}"
+          expression: '/CoverageSession/Summary/@sequenceCoverage'
       
       - name: branchCoverage
-        uses: mavrosxristoforos/get-xml-info@1.0
+        uses: QwerMike/xpath-action@v1
         with:
-          xml-file: "${{ env.COVERAGE_FILE }}"
-          xpath: '/CoverageSession/Summary[1]@branchCoverage'
+          filename: "${{ env.COVERAGE_FILE }}"
+          filename: '/CoverageSession/Summary/@branchCoverage'
       
       - uses: mshick/add-pr-comment@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         unityVersion:
           - 2019.4.0f1
         testMode:
-          # - PlayMode
+          # - playmode
           - editmode
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,6 @@ jobs:
           key: Library-Tests-${{ hashFiles('Packages/manifest.json') }}
           restore-keys: |
             Library-Tests-
-            Library-
 
       - name: Cache git lfs
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,12 +68,13 @@ jobs:
           path: ${{ steps.tests.outputs.artifactsPath }}
       
       - name: findCoverage
-        run: find . -name "TestCoverageResults_0000.xml"
+        run: |
+          echo ::set-env name=COVERAGE_FILE::$(find . -name "TestCoverageResults_0000.xml")
       
       - name: sequenceCoverage
         uses: mavrosxristoforos/get-xml-info@1.0
         with:
-          xml-file: "${{ steps.findCoverage.output }}"
+          xml-file: "${{ env.COVERAGE_FILE }}"
           xpath: '/CoverageSession/Summary@sequenceCoverage'
       
       - name: branchCoverage


### PR DESCRIPTION
# Description

Attempting to add code coverage reports to github actions. (and verification) just a draft for now.

# How Has This Been Tested?

Testing with github PR draft [https://github.com/nicholas-maltbie/PropHunt/actions/runs/248481330](https://github.com/nicholas-maltbie/PropHunt/actions/runs/248481330) Example execution with test coverage. 

Will generate comments with this format: 

> Test Coverage Results for editmode:
> Sequence Coverage: 3.55%
> Branch Coverage: 0.0%
> Link to run results: https://github.com/nicholas-maltbie/PropHunt/actions/runs/248481330


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~New and existing unit tests pass locally with my changes~~

(No testing framework setup yet so ignore the last two)

