### PR TITLE
Add optional jump grace time, and cooldown - Closes #34

### DIFF
--- a/Assets/NetCodeGenerated/PropHunt.Generated/PropHunt.Mixed.Components.KCCJumpingSerializer.cs
+++ b/Assets/NetCodeGenerated/PropHunt.Generated/PropHunt.Mixed.Components.KCCJumpingSerializer.cs
@@ -21,7 +21,7 @@ namespace PropHunt.Generated
         {
             State = new GhostComponentSerializer.State
             {
-                GhostFieldsHash = 270396784890700208,
+                GhostFieldsHash = 4539255436592233441,
                 ExcludeFromComponentCollectionHash = 0,
                 ComponentType = ComponentType.ReadWrite<PropHunt.Mixed.Components.KCCJumping>(),
                 ComponentSize = UnsafeUtility.SizeOf<PropHunt.Mixed.Components.KCCJumping>(),
@@ -54,8 +54,11 @@ namespace PropHunt.Generated
         {
             public int jumpForce;
             public uint attemptingJump;
+            public int jumpGraceTime;
+            public int jumpCooldown;
+            public int timeElapsedSinceJump;
         }
-        public const int ChangeMaskBits = 2;
+        public const int ChangeMaskBits = 5;
         [BurstCompile]
         [MonoPInvokeCallback(typeof(GhostComponentSerializer.CopyToFromSnapshotDelegate))]
         private static void CopyToSnapshot(IntPtr stateData, IntPtr snapshotData, int snapshotOffset, int snapshotStride, IntPtr componentData, int componentStride, int count)
@@ -67,6 +70,9 @@ namespace PropHunt.Generated
                 ref var serializerState = ref GhostComponentSerializer.TypeCast<GhostSerializerState>(stateData, 0);
                 snapshot.jumpForce = (int) math.round(component.jumpForce * 100);
                 snapshot.attemptingJump = component.attemptingJump?1u:0;
+                snapshot.jumpGraceTime = (int) math.round(component.jumpGraceTime * 100);
+                snapshot.jumpCooldown = (int) math.round(component.jumpCooldown * 100);
+                snapshot.timeElapsedSinceJump = (int) math.round(component.timeElapsedSinceJump * 100);
             }
         }
         [BurstCompile]
@@ -86,6 +92,15 @@ namespace PropHunt.Generated
                     math.lerp(snapshotBefore.jumpForce * 0.01f,
                         snapshotAfter.jumpForce * 0.01f, snapshotInterpolationFactor);
                 component.attemptingJump = snapshotBefore.attemptingJump != 0;
+                component.jumpGraceTime =
+                    math.lerp(snapshotBefore.jumpGraceTime * 0.01f,
+                        snapshotAfter.jumpGraceTime * 0.01f, snapshotInterpolationFactor);
+                component.jumpCooldown =
+                    math.lerp(snapshotBefore.jumpCooldown * 0.01f,
+                        snapshotAfter.jumpCooldown * 0.01f, snapshotInterpolationFactor);
+                component.timeElapsedSinceJump =
+                    math.lerp(snapshotBefore.timeElapsedSinceJump * 0.01f,
+                        snapshotAfter.timeElapsedSinceJump * 0.01f, snapshotInterpolationFactor);
             }
         }
         [BurstCompile]
@@ -96,6 +111,9 @@ namespace PropHunt.Generated
             ref var backup = ref GhostComponentSerializer.TypeCast<PropHunt.Mixed.Components.KCCJumping>(backupData, 0);
             component.jumpForce = backup.jumpForce;
             component.attemptingJump = backup.attemptingJump;
+            component.jumpGraceTime = backup.jumpGraceTime;
+            component.jumpCooldown = backup.jumpCooldown;
+            component.timeElapsedSinceJump = backup.timeElapsedSinceJump;
         }
 
         [BurstCompile]
@@ -107,6 +125,9 @@ namespace PropHunt.Generated
             ref var baseline2 = ref GhostComponentSerializer.TypeCast<Snapshot>(baseline2Data);
             snapshot.jumpForce = predictor.PredictInt(snapshot.jumpForce, baseline1.jumpForce, baseline2.jumpForce);
             snapshot.attemptingJump = (uint)predictor.PredictInt((int)snapshot.attemptingJump, (int)baseline1.attemptingJump, (int)baseline2.attemptingJump);
+            snapshot.jumpGraceTime = predictor.PredictInt(snapshot.jumpGraceTime, baseline1.jumpGraceTime, baseline2.jumpGraceTime);
+            snapshot.jumpCooldown = predictor.PredictInt(snapshot.jumpCooldown, baseline1.jumpCooldown, baseline2.jumpCooldown);
+            snapshot.timeElapsedSinceJump = predictor.PredictInt(snapshot.timeElapsedSinceJump, baseline1.timeElapsedSinceJump, baseline2.timeElapsedSinceJump);
         }
         [BurstCompile]
         [MonoPInvokeCallback(typeof(GhostComponentSerializer.CalculateChangeMaskDelegate))]
@@ -117,7 +138,10 @@ namespace PropHunt.Generated
             uint changeMask;
             changeMask = (snapshot.jumpForce != baseline.jumpForce) ? 1u : 0;
             changeMask |= (snapshot.attemptingJump != baseline.attemptingJump) ? (1u<<1) : 0;
-            GhostComponentSerializer.CopyToChangeMask(bits, changeMask, startOffset, 2);
+            changeMask |= (snapshot.jumpGraceTime != baseline.jumpGraceTime) ? (1u<<2) : 0;
+            changeMask |= (snapshot.jumpCooldown != baseline.jumpCooldown) ? (1u<<3) : 0;
+            changeMask |= (snapshot.timeElapsedSinceJump != baseline.timeElapsedSinceJump) ? (1u<<4) : 0;
+            GhostComponentSerializer.CopyToChangeMask(bits, changeMask, startOffset, 5);
         }
         [BurstCompile]
         [MonoPInvokeCallback(typeof(GhostComponentSerializer.SerializeDelegate))]
@@ -130,6 +154,12 @@ namespace PropHunt.Generated
                 writer.WritePackedIntDelta(snapshot.jumpForce, baseline.jumpForce, compressionModel);
             if ((changeMask & (1 << 1)) != 0)
                 writer.WritePackedUIntDelta(snapshot.attemptingJump, baseline.attemptingJump, compressionModel);
+            if ((changeMask & (1 << 2)) != 0)
+                writer.WritePackedIntDelta(snapshot.jumpGraceTime, baseline.jumpGraceTime, compressionModel);
+            if ((changeMask & (1 << 3)) != 0)
+                writer.WritePackedIntDelta(snapshot.jumpCooldown, baseline.jumpCooldown, compressionModel);
+            if ((changeMask & (1 << 4)) != 0)
+                writer.WritePackedIntDelta(snapshot.timeElapsedSinceJump, baseline.timeElapsedSinceJump, compressionModel);
         }
         [BurstCompile]
         [MonoPInvokeCallback(typeof(GhostComponentSerializer.DeserializeDelegate))]
@@ -146,6 +176,18 @@ namespace PropHunt.Generated
                 snapshot.attemptingJump = reader.ReadPackedUIntDelta(baseline.attemptingJump, compressionModel);
             else
                 snapshot.attemptingJump = baseline.attemptingJump;
+            if ((changeMask & (1 << 2)) != 0)
+                snapshot.jumpGraceTime = reader.ReadPackedIntDelta(baseline.jumpGraceTime, compressionModel);
+            else
+                snapshot.jumpGraceTime = baseline.jumpGraceTime;
+            if ((changeMask & (1 << 3)) != 0)
+                snapshot.jumpCooldown = reader.ReadPackedIntDelta(baseline.jumpCooldown, compressionModel);
+            else
+                snapshot.jumpCooldown = baseline.jumpCooldown;
+            if ((changeMask & (1 << 4)) != 0)
+                snapshot.timeElapsedSinceJump = reader.ReadPackedIntDelta(baseline.timeElapsedSinceJump, compressionModel);
+            else
+                snapshot.timeElapsedSinceJump = baseline.timeElapsedSinceJump;
         }
         #if UNITY_EDITOR || DEVELOPMENT_BUILD
         [BurstCompile]
@@ -159,6 +201,12 @@ namespace PropHunt.Generated
             ++errorIndex;
             errors[errorIndex] = math.max(errors[errorIndex], (component.attemptingJump != backup.attemptingJump) ? 1 : 0);
             ++errorIndex;
+            errors[errorIndex] = math.max(errors[errorIndex], math.abs(component.jumpGraceTime - backup.jumpGraceTime));
+            ++errorIndex;
+            errors[errorIndex] = math.max(errors[errorIndex], math.abs(component.jumpCooldown - backup.jumpCooldown));
+            ++errorIndex;
+            errors[errorIndex] = math.max(errors[errorIndex], math.abs(component.timeElapsedSinceJump - backup.timeElapsedSinceJump));
+            ++errorIndex;
         }
         private static int GetPredictionErrorNames(ref FixedString512 names)
         {
@@ -170,6 +218,18 @@ namespace PropHunt.Generated
             if (nameCount != 0)
                 names.Append(new FixedString32(","));
             names.Append(new FixedString64("attemptingJump"));
+            ++nameCount;
+            if (nameCount != 0)
+                names.Append(new FixedString32(","));
+            names.Append(new FixedString64("jumpGraceTime"));
+            ++nameCount;
+            if (nameCount != 0)
+                names.Append(new FixedString32(","));
+            names.Append(new FixedString64("jumpCooldown"));
+            ++nameCount;
+            if (nameCount != 0)
+                names.Append(new FixedString32(","));
+            names.Append(new FixedString64("timeElapsedSinceJump"));
             ++nameCount;
             return nameCount;
         }

--- a/Assets/Prefabs/Characters/TestCharacter.prefab
+++ b/Assets/Prefabs/Characters/TestCharacter.prefab
@@ -171,6 +171,10 @@ MonoBehaviour:
   moveMaxBounces: 3
   fallMaxBounces: 3
   pushDecay: 0.1
+  jumpGraceTime: 0.1
+  elapsedFallTime: 0
+  jumpCooldown: 0.3
+  timeElapsedSinceJump: 0
 --- !u!114 &2032777291050987007
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Authoring/PlayerMovementAuthoringComponent.cs
+++ b/Assets/Scripts/Authoring/PlayerMovementAuthoringComponent.cs
@@ -82,17 +82,7 @@ namespace PropHunt.Authoring
         /// <summary>
         /// Time spent falling
         /// </summary>
-        public float elapsedFallTime = 0.0f;
-
-        /// <summary>
-        /// Time spent falling
-        /// </summary>
         public float jumpCooldown = 0.1f;
-
-        /// <summary>
-        /// Time elapsed since last jump. 
-        /// </summary>
-        public float timeElapsedSinceJump = 0.11f;
 
         public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
         {
@@ -114,13 +104,11 @@ namespace PropHunt.Authoring
                 jumpForce = this.jumpForce,
                 jumpGraceTime = this.jumpGraceTime,
                 jumpCooldown = this.jumpCooldown,
-                timeElapsedSinceJump = this.timeElapsedSinceJump,
             });
             dstManager.AddComponentData(entity, new KCCGrounded()
             {
                 maxWalkAngle = this.maxWalkAngle,
                 groundCheckDistance = this.groundCheckDistance,
-                elapsedFallTime = this.elapsedFallTime,
             });
             dstManager.AddComponentData(entity, new KCCVelocity()
             {

--- a/Assets/Scripts/Authoring/PlayerMovementAuthoringComponent.cs
+++ b/Assets/Scripts/Authoring/PlayerMovementAuthoringComponent.cs
@@ -74,6 +74,8 @@ namespace PropHunt.Authoring
         /// <summary>
         /// Duration of jumping grace period
         ///     - Player can jump while not grounded, as long as they haven't been grounded longer than this amount of time
+        ///     - Make sure the value of jumpGraceTime < jumpCooldown. 
+        ///       Otherwise, double jumps are possible.
         /// </summary>
         public float jumpGraceTime = 0.0f;
 
@@ -89,8 +91,6 @@ namespace PropHunt.Authoring
 
         /// <summary>
         /// Time elapsed since last jump. 
-        ///     - Make sure the value of timeElapsedSinceJump > jumpCooldown. 
-        ///       Otherwise, double jumps are possible
         /// </summary>
         public float timeElapsedSinceJump = 0.11f;
 

--- a/Assets/Scripts/Authoring/PlayerMovementAuthoringComponent.cs
+++ b/Assets/Scripts/Authoring/PlayerMovementAuthoringComponent.cs
@@ -71,6 +71,29 @@ namespace PropHunt.Authoring
         /// </summary>
         public float pushDecay = 0.0f;
 
+        /// <summary>
+        /// Duration of jumping grace period
+        ///     - Player can jump while not grounded, as long as they haven't been grounded longer than this amount of time
+        /// </summary>
+        public float jumpGraceTime = 0.0f;
+
+        /// <summary>
+        /// Time spent falling
+        /// </summary>
+        public float elapsedFallTime = 0.0f;
+
+        /// <summary>
+        /// Time spent falling
+        /// </summary>
+        public float jumpCooldown = 0.1f;
+
+        /// <summary>
+        /// Time elapsed since last jump. 
+        ///     - Make sure the value of timeElapsedSinceJump > jumpCooldown. 
+        ///       Otherwise, double jumps are possible
+        /// </summary>
+        public float timeElapsedSinceJump = 0.11f;
+
         public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
         {
             dstManager.AddComponentData(entity, new KCCMovementSettings()
@@ -89,11 +112,15 @@ namespace PropHunt.Authoring
             dstManager.AddComponentData(entity, new KCCJumping()
             {
                 jumpForce = this.jumpForce,
+                jumpGraceTime = this.jumpGraceTime,
+                jumpCooldown = this.jumpCooldown,
+                timeElapsedSinceJump = this.timeElapsedSinceJump,
             });
             dstManager.AddComponentData(entity, new KCCGrounded()
             {
                 maxWalkAngle = this.maxWalkAngle,
                 groundCheckDistance = this.groundCheckDistance,
+                elapsedFallTime = this.elapsedFallTime,
             });
             dstManager.AddComponentData(entity, new KCCVelocity()
             {

--- a/Assets/Scripts/Mixed/Components/KinematicCharacterControllerComponents.cs
+++ b/Assets/Scripts/Mixed/Components/KinematicCharacterControllerComponents.cs
@@ -93,6 +93,28 @@ namespace PropHunt.Mixed.Components
         /// </summary>
         [GhostField]
         public bool attemptingJump;
+
+        /// <summary>
+        /// Duration of jumping grace period
+        ///     - Player can jump while not grounded, as long as they haven't been grounded longer than this amount of time
+        /// </summary>
+        [GhostField(Quantization = 100, Interpolate = true)]
+        public float jumpGraceTime;
+
+        /// <summary>
+        /// Minimum time between jumps
+        /// </summary>
+        [GhostField(Quantization = 100, Interpolate = true)]
+        public float jumpCooldown;
+
+        /// <summary>
+        /// Time elapsed since last jump. 
+        /// Used in conjunction with jumpCooldown
+        /// </summary>
+        [GhostField(Quantization = 100, Interpolate = true)]
+        public float timeElapsedSinceJump;
+
+
     }
 
     /// <summary>
@@ -155,6 +177,12 @@ namespace PropHunt.Mixed.Components
         /// Entity hit
         /// </summary>
         public Entity hitEntity;
+
+        /// <summary>
+        /// Time spent falling
+        /// </summary>
+        [GhostField(Quantization = 100, Interpolate = true)]
+        public float elapsedFallTime;
     }
 
     /// <summary>

--- a/Assets/Scripts/Mixed/Systems/KinematicCharacterControllerSystems.cs
+++ b/Assets/Scripts/Mixed/Systems/KinematicCharacterControllerSystems.cs
@@ -179,13 +179,12 @@ namespace PropHunt.Mixed.Systems
                         velocity.worldVelocity += gravity.Up * jumping.jumpForce;
                         jumping.timeElapsedSinceJump = 0.0f;
                     }
-                    // Otherwise, do nothing
-
-                    // Track jumping cooldown
-                    if (jumping.timeElapsedSinceJump < jumping.jumpCooldown)
+                    // Track jumping cooldown if not jumping
+                    else if (jumping.timeElapsedSinceJump < jumping.jumpCooldown)
                     {
                         jumping.timeElapsedSinceJump += deltaTime;
                     }
+                    // Otherwise do nothing
                 }
             ).ScheduleParallel();
         }


### PR DESCRIPTION
# Description
This allows for more forgiving jumps off edges. The cooldown should be used alongside the grace time to avoid allowing abnormal double jumps.

Several fields were added to the player movement component:

- Jump Grace TIme
- Elapsed Fall Time
^ These fields allow the addition of a 'jumping grace period,' where a player can jump even if they're not grounded. This should make jumping off cliffs feel better.

- Jump Cooldown
- Time Elapsed Since Jump
^ These fields assist in adding a jump grace time, preventing double jumping. **The Jump Cooldown should not be set above the Grace time**, since this would allow for potential double jumping. This is recorded in the C# XML docs above the .

# How Has This Been Tested?
I ran around the map, checking the feel of the grace period and making sure double jumping is possible. 

On my first attempt to get this working, the 'spinning plate' object wasn't working as intended, as the player would lose all horizontal momentum when jumping off of it. At this point, that, too, is working fine.

After adding the first two 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
      ^ I have included C# XML documentation comments
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~New and existing unit tests pass locally with my changes~~

(No testing framework setup yet so ignore the last two)
